### PR TITLE
typo on markdown tools names

### DIFF
--- a/_posts/2012-08-10-SUBLIMETEXT2.md
+++ b/_posts/2012-08-10-SUBLIMETEXT2.md
@@ -121,7 +121,7 @@ Le format markdown devient incontournable (pour rédiger la doc de vos projets p
 
 - `Ctrl + Shift + P` (ou Tools + Command Palette ...)
 - Sélectionner :  "Package Control: Install Package"
-- Chercher : markdowndpreview
+- Chercher : markdownpreview
 - Installer
 
 ####Utiliser
@@ -134,7 +134,7 @@ Lorsque vous êtes en édition d'un fichier markdown : `Ctrl + Shift + P` puis t
 
 - `Ctrl + Shift + P` (ou Tools + Command Palette ...)
 - Sélectionner :  "Package Control: Install Package"
-- Chercher : markdowndbuils
+- Chercher : markdownbuild
 - Installer
 
 ####Utiliser


### PR DESCRIPTION
by the way, CTRL+B on a markdown file generate errors and the syntax doen't look as expected.
I used ### and it wasn't transformed.
